### PR TITLE
Change the AWS env vars to match CI-slave-images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ It is a subset of the existing Ansible code from [ansible-jenkins-showcase](http
 
 To use it:
 
+0. Install vagrant, rake, mkmf and virtualbox
+
 1. clone this repostory
 
         git clone http://github.com/clusterhq/ci-platform.git
@@ -25,7 +27,17 @@ Note: the ansible 'vault' file is not currently used, as soon it is required, it
 
 The secrets-repo above contains the YAML dictionary (group_vars/all.yaml) used by Ansible to configure the instance.
 
-5. Then simply run:
+5. for aws, you need to export your aws environment variables (the same ones
+   used by the CI-slave-images project):
+
+    export AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY
+    export AWS_KEY_PAIR
+    export AWS_KEY_FILENAME
+
+Note that your ssh key referred to by AWS_KEY_FILENAME can't have a passphrase set.
+
+6. Then simply run:
 
         rake default aws
 
@@ -34,11 +46,4 @@ The secrets-repo above contains the YAML dictionary (group_vars/all.yaml) used b
 and connect to [http://jenkins:8080](http://jenkins:8080)
 
 you should see a fully deployed, configured jenkins ready to bootstrap EC2 slaves.
-
-for aws, you need to export your aws environment variables.
-
-    export AWS_ACCESS_KEY_ID
-    export AWS_SECRET_KEY
-    export AWS_KEYPAIR_NAME
-    export AWS_KEYPAIR_FILEPATH
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The secrets-repo above contains the YAML dictionary (group_vars/all.yaml) used b
 5. for aws, you need to export your aws environment variables (the same ones
    used by the CI-slave-images project):
 
-    export AWS_ACCESS_KEY_ID
-    export AWS_SECRET_ACCESS_KEY
-    export AWS_KEY_PAIR
-    export AWS_KEY_FILENAME
+    * AWS_KEY_PAIR (the KEY_PAIR to use)
+    * AWS_KEY_FILENAME (the full path to your .pem file)
+    * AWS_SECRET_ACCESS_KEY
+    * AWS_ACCESS_KEY_ID
 
 Note that your ssh key referred to by AWS_KEY_FILENAME can't have a passphrase set.
 

--- a/Vagrantfile.aws
+++ b/Vagrantfile.aws
@@ -10,9 +10,9 @@ end
 
 # Check that all the required environment variables have been set
 ENV['AWS_ACCESS_KEY_ID'] ? true : exit_with_message('AWS_ACCESS_KEY_ID not set')
-ENV['AWS_SECRET_KEY'] ? true : exit_with_message('AWS_SECRET_KEY not set')
-ENV['AWS_KEYPAIR_NAME'] ? true : exit_with_message('AWS_KEYPAIR_NAME not set')
-ENV['AWS_KEYPAIR_FILEPATH'] ? true : exit_with_message('AWS_KEYPAIR_FILEPATH not set')
+ENV['AWS_SECRET_ACCESS_KEY'] ? true : exit_with_message('AWS_SECRET_ACCESS_KEY not set')
+ENV['AWS_KEY_PAIR'] ? true : exit_with_message('AWS_KEY_PAIR not set')
+ENV['AWS_KEY_FILENAME'] ? true : exit_with_message('AWS_KEY_FILENAME not set')
 
 boxes = [
   {
@@ -42,8 +42,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       machine.vm.provider :aws do |aws, override|
         aws.access_key_id = ENV['AWS_ACCESS_KEY_ID']
-        aws.secret_access_key = ENV['AWS_SECRET_KEY']
-        aws.keypair_name = ENV['AWS_KEYPAIR_NAME']
+        aws.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+        aws.keypair_name = ENV['AWS_KEY_PAIR']
         aws.security_groups = ['ssh', 'http', 'jenkins-master', 'high-ports']
         aws.ami = "ami-1255b321"
         aws.region = "us-west-2"
@@ -56,12 +56,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           'owner' => ENV['USER']
         }
 
-        override.ssh.private_key_path = ENV['AWS_KEYPAIR_FILEPATH']
+        override.ssh.private_key_path = ENV['AWS_KEY_FILENAME']
         machine.vm.box = "#{opts[:name].to_s}-aws"
         override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
         override.ssh.username = 'centos'
         machine.ssh.username = 'centos'
-        machine.ssh.private_key_path = ENV['AWS_KEYPAIR_FILEPATH']
+        machine.ssh.private_key_path = ENV['AWS_KEY_FILENAME']
       end
 
       config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
Both projects need the same AWS creds from the environment,
so they should use the same names for them to make it easier
to work on both projects.

This also slightly improves the docs to make getting started
easier.