### PR TITLE
[FLOC-3938] Don't trigger release setup on github push

### DIFF
--- a/roles/local.Azulinho.azulinho-jenkins-reconfigure-jobs-using-job-dsl/files/seed_jobs_definitions/setup_ClusterHQ-flocker-release
+++ b/roles/local.Azulinho.azulinho-jenkins-reconfigure-jobs-using-job-dsl/files/seed_jobs_definitions/setup_ClusterHQ-flocker-release
@@ -46,11 +46,6 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers>
-    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.10">
-      <spec></spec>
-    </com.cloudbees.jenkins.GitHubPushTrigger>
-  </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>


### PR DESCRIPTION
This should only be done when requested, as it races with the non-release
job for defining the config for any particular branch.

Removing the trigger means it will be run by hand for specific
branches when neeed.