### PR TITLE
[FLOC-3962] Render acceptance.yml as a template so newlines are preserved.

### DIFF
--- a/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
@@ -168,8 +168,8 @@
   # have to double escape backslashes so that when this is evaluated as yaml
   # (or perhaps for when the string is evaluated by the ansible command
   # processor) they are preserved.
-  copy: content='{{ acceptance["config"] | to_json | replace("\\", "\\\\")}}'
-    dest=/etc/slave_config/acceptance.yaml
+  template: dest=/etc/slave_config/acceptance.yaml
+
   tags: ['jenkins', 'jenkins_config']
 
 - name: Copy ssh key contents of acceptance.yaml to slave dir

--- a/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
@@ -164,11 +164,8 @@
   tags: ['jenkins', 'jenkins_config']
 
 - name: Copy config contents of acceptance.yaml to config dir
-  # Jinja is nice enough to render our accpetance yaml blob as JSON, but we
-  # have to double escape backslashes so that when this is evaluated as yaml
-  # (or perhaps for when the string is evaluated by the ansible command
-  # processor) they are preserved.
   template: dest=/etc/slave_config/acceptance.yaml
+    src=acceptance.yaml.j2
 
   tags: ['jenkins', 'jenkins_config']
 

--- a/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
@@ -164,7 +164,11 @@
   tags: ['jenkins', 'jenkins_config']
 
 - name: Copy config contents of acceptance.yaml to config dir
-  copy: content="{{ acceptance.config }}"
+  # Jinja is nice enough to render our accpetance yaml blob as JSON, but we
+  # have to double escape backslashes so that when this is evaluated as yaml
+  # (or perhaps for when the string is evaluated by the ansible command
+  # processor) they are preserved.
+  copy: content='{{ acceptance["config"] | to_json | replace("\\", "\\\\")}}'
     dest=/etc/slave_config/acceptance.yaml
   tags: ['jenkins', 'jenkins_config']
 

--- a/roles/local.Azulinho.azulinho-jenkins-server/templates/acceptance.yaml.j2
+++ b/roles/local.Azulinho.azulinho-jenkins-server/templates/acceptance.yaml.j2
@@ -1,0 +1,1 @@
+{{ acceptance["config"] | to_yaml }}


### PR DESCRIPTION
Prior to this commit, jinja2 was implicitly rendering acceptance.config as 
_something_, and this something could be parsed by the python yaml library.
This worked fine for everything _except_ for the new private key that is going
to be added in order to do authentication with GCE.

Using the template ansible command to render the jinja2 directly so that we get to keep the whitespace in the yaml file. (It seems that specifying content directly in the ansible recipe results in the whitespace being eaten by some different layer of yaml parsing)