### PR TITLE
[Floc 4114] ensure master can only start, communicate and kill their own slaves

### DIFF
--- a/roles/local.Azulinho.azulinho-jenkins-server/templates/do_ec2_plugin.xml.j2
+++ b/roles/local.Azulinho.azulinho-jenkins-server/templates/do_ec2_plugin.xml.j2
@@ -41,10 +41,14 @@
           <tags>
 {%                  for tag in t.tags %}
             <hudson.plugins.ec2.EC2Tag>
-            <name>{{ tag.name }}</name>
-            <value>{{ tag.value }}</value>
+              <name>{{ tag.name }}</name>
+              <value>{{ tag.value }}</value>
             </hudson.plugins.ec2.EC2Tag>
 {%                  endfor            %}
+            <hudson.plugins.ec2.EC2Tag>
+              <name>jenkins_master</name>
+              <value>{{ansible_ec2_public_ipv4}} {{ ansible_hostname }}</value>
+            </hudson.plugins.ec2.EC2Tag>
           </tags>
           <usePrivateDnsName>{{ t.usePrivateDnsName |default('false')}}</usePrivateDnsName>
           <associatePublicIp>{{ t.associatePublicIp | default('false')}}</associatePublicIp>


### PR DESCRIPTION
Add tag to slave so Jenkins masters can only talk, stop and start slaves they have started.