### PR TITLE
Gce static slaves

### DIFF
--- a/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
@@ -62,7 +62,7 @@
 
 - name: uninstall jenkins if installed version not equal to configured version (notifies restart)
   yum: name=jenkins state=absent
-  when: ( is_jenkins_installed.stdout.find('is not installed') == -1 ) and  
+  when: ( is_jenkins_installed.stdout.find('is not installed') == -1 ) and
         ( azulinho_jenkins_server['version'] != jenkins_installed_version.stdout)
   tags: ['jenkins', 'versionlock']
   notify:
@@ -402,7 +402,7 @@
 
 - name: Retrieve the CloudBees password from Jenkins
   shell: java -jar {{ azulinho_jenkins_server['cli_dest'] }} -s http://localhost:{{ azulinho_jenkins_server['port'] }}/ groovy {{ azulinho_jenkins_server['lib'] }}/cloudbees.groovy
-  tags: ['jenkins', 'jenkins_config', 'cloudbees']
+  tags: ['jenkins', 'jenkins_config', 'cloudbees', 'xml_conf_files']
   register: cloudbees_encrypted_password
   notify:
     - safe-restart jenkins
@@ -437,6 +437,22 @@
   notify:
     - safe-restart jenkins
 
+- name: Create directories for slave node configuration
+  file: path={{ azulinho_jenkins_server['lib'] }}/nodes/{{ item.key }} state=directory
+  tags: ['jenkins', 'jenkins_config', 'xml_conf_files', 'cloudbees']
+  with_dict: "azulinho_jenkins_server['static_slaves']"
+
+- name: Create slave node file for nodes
+  template: dest={{ azulinho_jenkins_server['lib'] }}/nodes/{{ item.key }}/config.xml
+    src=nodes/node_name/config.xml.j2
+    owner=jenkins
+    group=jenkins
+  tags: ['jenkins', 'jenkins_config', 'xml_conf_files', 'cloudbees']
+  with_dict: "azulinho_jenkins_server['static_slaves']"
+  notify:
+    - safe-restart jenkins
+
+
 # Deploy the CloudBees Slave Configuration templates
 # we use these to specify which size our slaves should be
 - name: Create cloudbees CloudSlaveTemplates dir
@@ -467,4 +483,3 @@
     dest=/etc/hosts
     line='{{ansible_ec2_public_ipv4}} {{ ansible_hostname }}'
   tags: ['jenkins', 'hosts', 'mesos']
-

--- a/roles/local.Azulinho.azulinho-jenkins-server/templates/credentials.xml.j2
+++ b/roles/local.Azulinho.azulinho-jenkins-server/templates/credentials.xml.j2
@@ -21,10 +21,17 @@
           <description></description>
           <secret>{{ github_pr_secret }}</secret>
         </org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl>
-
-
+        <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey plugin="ssh-credentials@1.10">
+          <scope>GLOBAL</scope>
+          <id>9a0d57ba-6ade-4d01-85da-a1b910fd8dda</id>
+          <description>SSH key to log onto jenkins slaves, assumes username is jenkins</description>
+          <username>jenkins</username>
+          <passphrase>A1VgmtJPDZ+L4ZWzugLaaA==</passphrase>
+          <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$FileOnMasterPrivateKeySource">
+            <privateKeyFile>/etc/slave_config/jenkins-slave.ssh.private_key</privateKeyFile>
+          </privateKeySource>
+        </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
       </java.util.concurrent.CopyOnWriteArrayList>
     </entry>
   </domainCredentialsMap>
 </com.cloudbees.plugins.credentials.SystemCredentialsProvider>
-

--- a/roles/local.Azulinho.azulinho-jenkins-server/templates/nodes/node_name/config.xml.j2
+++ b/roles/local.Azulinho.azulinho-jenkins-server/templates/nodes/node_name/config.xml.j2
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<slave>
+  <name>{{ item.key }}</name>
+  <description> {{item.value.description }} </description>
+  <remoteFS>/tmp</remoteFS>
+  <numExecutors>1</numExecutors>
+  <mode>NORMAL</mode>
+  <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
+  <launcher class="hudson.plugins.sshslaves.SSHLauncher" plugin="ssh-slaves@1.9">
+    <host>{{ item.value.ip }}</host>
+    <port>22</port>
+    <credentialsId>9a0d57ba-6ade-4d01-85da-a1b910fd8dda</credentialsId>
+    <maxNumRetries>0</maxNumRetries>
+    <retryWaitTime>0</retryWaitTime>
+  </launcher>
+  <label>{{ item.value.label }}</label>
+  <nodeProperties/>
+  <userId>admin</userId>
+</slave>


### PR DESCRIPTION
Since we cannot dynamically launch GCE slaves from jenkins, we must configure Jenkins to have a couple of GCE static slaves attached to it.  This PR creates the node configuration on the master from data in segredos.  A corresponding PR for segredos is forthcoming.