### PR TITLE
 [FLOC-4176] statically-configure-known-jenkins-recorders

### DIFF
--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2AbstractSlave.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2AbstractSlave.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2AbstractSlave</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2AbstractSlave</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2Cloud.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2Cloud.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2Cloud</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2Cloud</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2ComputerLauncher.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2ComputerLauncher.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2ComputerLauncher</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2ComputerLauncher</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2OndemandSlave.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2OndemandSlave.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2OndemandSlave</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2OndemandSlave</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2RetentionStrategy.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2RetentionStrategy.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2RetentionStrategy</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2RetentionStrategy</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2SlaveMonitor.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.EC2SlaveMonitor.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.EC2SlaveMonitor</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.EC2SlaveMonitor</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.SlaveTemplate.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.SlaveTemplate.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.SlaveTemplate</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.SlaveTemplate</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.ebs.ZPoolMonitor.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.ebs.ZPoolMonitor.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.ebs.ZPoolMonitor</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.ebs.ZPoolMonitor</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.ssh.EC2UnixLauncher.xml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/files/log/hudson.plugins.ec2.ssh.EC2UnixLauncher.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log>
+  <name>hudson.plugins.ec2.ssh.EC2UnixLauncher</name>
+  <targets>
+    <target>
+      <name>hudson.plugins.ec2.ssh.EC2UnixLauncher</name>
+      <level>-2147483648</level>
+    </target>
+  </targets>
+</log>

--- a/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
+++ b/roles/local.Azulinho.azulinho-jenkins-server/tasks/main.yaml
@@ -332,6 +332,13 @@
   notify:
     - safe-restart jenkins
 
+- name: Configure log recorders
+  copy: dest={{ azulinho_jenkins_server['lib'] }}/log
+    src=log/
+  tags: ['jenkins', 'jenkins_config', 'xml_conf_files']
+  notify:
+    - safe-restart jenkins
+
 # Start jenkins, we need it up and running before we are able to download
 # the CLI tool
 - name: Ensure jenkins is running


### PR DESCRIPTION
Ensure that jenkins instances come fully baked with some useful logging configured.

A side effect of this change will be to expose information that up to know required logging into the build server.
 